### PR TITLE
Make fields that Slack requires on Action as required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-[Unreleased]: https://github.com/atomist/slack-messages/compare/0.2.0...0.1.0
+[Unreleased]: https://github.com/atomist/slack-messages/compare/0.3.0...0.2.0
+
+### Changed
+-   **BREAKING** `Action` fields `name` and `type` are now required in order 
+    to match Slack required fields
 
 ## [0.2.0]: - 2017-05-09
 

--- a/src/SlackMessages.ts
+++ b/src/SlackMessages.ts
@@ -165,8 +165,8 @@ export interface Field {
  */
 export interface Action {
     text: string;
-    name?: string;
-    type?: ActionType;
+    name: string;
+    type: ActionType;
     value?: string;
     style?: string;
     confirm?: ActionConfirmation;
@@ -182,16 +182,24 @@ export interface ActionConfirmation {
 
 type ActionType = "button";
 
+export class ButtonSpec {
+    public text: string;
+    public style?: string;
+    public confirm?: ActionConfirmation;
+}
+
 /** Construct Slack button that will execute provided rug instruction. */
-export function rugButtonFrom(action: Action, command: Presentable<any>): Action {
-    const button: Action = { text: action.text };
+export function rugButtonFrom(action: ButtonSpec, command: Presentable<any>): Action {
+    const button: Action = {
+        text: action.text,
+        type: "button",
+        name: "rug",
+        value: command.id,
+    };
     for (const attr in action) {
         if (action.hasOwnProperty(attr)) {
             button[attr] = action[attr];
         }
     }
-    button.type = "button";
-    button.name = "rug";
-    button.value = command.id;
     return button;
 }


### PR DESCRIPTION
Add separate ButtonSpec to enforce what fields can be
provided when constructing rug buttons