### PR TITLE
Add standard Slack messages and colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 [17]: https://github.com/atomist/slack-messages/issues/17
 
+### Added
+
+-   Standard Slack success, error, and warning messages and colors
+
+### Deprecated
+
+-   renderError and renderSuccess have been replaced by errorResponse
+    and successResponse
+
 ## [0.7.0] - 2017-07-04
 
 [0.7.0]: https://github.com/atomist/slack-messages/compare/0.6.0...0.7.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -224,6 +224,11 @@
         "object-keys": "1.0.11"
       }
     },
+    "deprecated-decorator": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/deprecated-decorator/-/deprecated-decorator-0.1.6.tgz",
+      "integrity": "sha1-AJZjF7ehL+kvPMgx91g68ym4bDc="
+    },
     "diff": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@atomist/rug": "^1.0.0-m.5",
+    "deprecated-decorator": "^0.1.6",
     "lodash": "^4.17.4"
   },
   "devDependencies": {

--- a/src/Common.ts
+++ b/src/Common.ts
@@ -1,3 +1,0 @@
-export function emptyString(str: string): boolean {
-    return str == null || str === "";
-}

--- a/src/Markdown.ts
+++ b/src/Markdown.ts
@@ -104,8 +104,8 @@ function convertMarkdown(text: string): string {
                     convertNamedLinks(
                         convertFormat(text)))));
     } catch (e) {
-        // tslint:disable-next-line:no-console
-        console.error(`replace failed: ${e}`);
+        const err = e as Error;
+        console.error(`replace failed:${err.name}:${err.message}:${err.stack}`);
         return text;
     }
 }

--- a/src/RugMessages.ts
+++ b/src/RugMessages.ts
@@ -1,11 +1,188 @@
-import { MessageMimeTypes, ResponseMessage } from "@atomist/rug/operations/Handlers";
-import { emptyString } from "./Common";
-import { Attachment, render } from "./SlackMessages";
-/**
+/*
+ * Copyright © 2017 Atomist, Inc.
  *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
-export function renderError(msg: string, correlationId?: string): ResponseMessage {
+import { MessageMimeTypes, ResponseMessage } from "@atomist/rug/operations/Handlers";
+
+import { deprecated } from "deprecated-decorator";
+
+import {
+    Attachment,
+    render,
+    SlackMessage,
+    url,
+} from "./SlackMessages";
+
+export const ErrorColor = "#D94649";
+export const SuccessColor = "#45B254";
+export const WarningColor = "#FFCC00";
+
+interface StandardAttachmentDefaults {
+    kind: string;
+    image: string;
+    color: string;
+}
+
+/**
+ * Populate standard message attachment with defaults if value not set.
+ *
+ * @param a attachment to ensure populated, possibly modified by this function
+ * @param sm default values
+ * @return populated attachment
+ */
+function standardAttachment(a: Attachment, sm: StandardAttachmentDefaults): Attachment {
+    a.fallback = a.fallback || `${sm.kind}!`;
+    a.text = a.text || a.fallback;
+    a.author_name = a.author_name || `${sm.kind}: ${a.fallback}`;
+    a.author_icon = a.author_icon || sm.image;
+    a.color = a.color || sm.color;
+    a.mrkdwn_in = a.mrkdwn_in || ["text"];
+    return a;
+}
+
+/**
+ * Create a standard Slack error message.  The attachment should
+ * contain at least a non-empty fallback property.  The text property
+ * will be augmented with information about getting help.  If the text
+ * property is not provided, the fallback is used as a base for the
+ * fallback.  Title icons and message will be added if they are not
+ * present.
+ *
+ * @param attachment  message content
+ * @param correlationId correlation ID for transaction that failed,
+ *                      which will appear in the footer if it is not already set
+ * @return a Slack error message using attachments which will need to be `render`ed
+ */
+export function errorMessage(attachment: Attachment, correlationId?: string): SlackMessage {
+    const defaults: StandardAttachmentDefaults = {
+        kind: "Error",
+        image: "https://images.atomist.com/rug/error-circle.png",
+        color: ErrorColor,
+    };
+    attachment = standardAttachment(attachment, defaults);
+    const supportUrl = "https://atomist-community.slack.com/messages/C29GYTYDC/";
+    attachment.text += `\nPlease contact ${url(supportUrl, "Atomist support")}`;
+    if (!attachment.footer && correlationId) {
+        attachment.text += `, providing the correlation ID below`;
+        attachment.footer = `Correlation ID: ${correlationId}`;
+    }
+    attachment.text += `. Sorry for the inconvenience.`;
+    const message: SlackMessage = { attachments: [attachment] };
+    return message;
+}
+
+/**
+ * Create a standard Slack success message.  The attachment should
+ * contain at least a non-empty fallback property.  If the text
+ * property is not provided, the fallback is used.  Title icons and
+ * message will be added if they are not present.
+ *
+ * @param attachment  message content
+ * @return a Slack success message using attachments which will need to be `render`ed
+ */
+export function successMessage(attachment: Attachment): SlackMessage {
+    const defaults: StandardAttachmentDefaults = {
+        kind: "Success",
+        image: "https://images.atomist.com/rug/check-circle.png",
+        color: SuccessColor,
+    };
+    attachment = standardAttachment(attachment, defaults);
+    const message: SlackMessage = { attachments: [attachment] };
+    return message;
+}
+
+/**
+ * Create a standard Slack warning message.  The attachment should
+ * contain at least a non-empty fallback property.  If the text
+ * property is not provided, the fallback is used.  Title icons and
+ * message will be added if they are not present.
+ *
+ * @param attachment  message content
+ * @return a Slack warning message using attachments which will need to be `render`ed
+ */
+export function warningMessage(attachment: Attachment): SlackMessage {
+    const defaults: StandardAttachmentDefaults = {
+        kind: "Warning",
+        image: "https://images.atomist.com/rug/error-square.png",
+        color: WarningColor,
+    };
+    attachment = standardAttachment(attachment, defaults);
+    const message: SlackMessage = { attachments: [attachment] };
+    return message;
+}
+
+/**
+ * Create a Rug error ResponseMessage.  If rendering fails, a text
+ * response message of attachment.fallback is returned.
+ *
+ * @param msg text of Slack message
+ * @param correlationId correlation ID of transaction that failed
+ * @return Rug error ResponseMessage
+ */
+export function errorResponse(attachment: Attachment, correlationId?: string): ResponseMessage {
+    try {
+        const slackMessage = errorMessage(attachment, correlationId);
+        return new ResponseMessage(render(slackMessage), MessageMimeTypes.SLACK_JSON);
+    } catch (e) {
+        const err = e as Error;
+        console.error(`failed to render message '${attachment}':${err.name}:${err.message}:${err.stack}`);
+        return new ResponseMessage(attachment.fallback);
+    }
+}
+
+/**
+ * Create a Rug success ResponseMessage.  If rendering fails, a text
+ * response message of attachment.fallback is returned.
+ *
+ * @param msg text of Slack message
+ * @return Rug success ResponseMessage
+ */
+export function successResponse(attachment: Attachment): ResponseMessage {
+    try {
+        const slackMessage = successMessage(attachment);
+        return new ResponseMessage(render(slackMessage), MessageMimeTypes.SLACK_JSON);
+    } catch (e) {
+        const err = e as Error;
+        console.error(`failed to render message '${attachment}':${err.name}:${err.message}:${err.stack}`);
+        return new ResponseMessage(attachment.fallback);
+    }
+}
+
+/**
+ * Create a Rug warning ResponseMessage.  If rendering fails, a text
+ * response message of attachment.fallback is returned.
+ *
+ * @param msg text of Slack message
+ * @return Rug warning ResponseMessage
+ */
+export function warningResponse(attachment: Attachment): ResponseMessage {
+    try {
+        const slackMessage = warningMessage(attachment);
+        return new ResponseMessage(render(slackMessage), MessageMimeTypes.SLACK_JSON);
+    } catch (e) {
+        const err = e as Error;
+        console.error(`failed to render message '${attachment}':${err.name}:${err.message}:${err.stack}`);
+        return new ResponseMessage(attachment.fallback);
+    }
+}
+
+/* tslint:disable:no-shadowed-variable */
+export const renderError = deprecated({
+    alternative: "errorResponse",
+    version: "0.8.0",
+}, function renderError(msg: string, correlationId?: string): ResponseMessage {
     try {
         const error: Attachment = {
             text: msg,
@@ -15,7 +192,7 @@ export function renderError(msg: string, correlationId?: string): ResponseMessag
             mrkdwn_in: ["text"],
             color: "#D94649",
         };
-        if (!emptyString(correlationId)) {
+        if (correlationId) {
             error.footer = `Correlation ID: ${correlationId}`;
         }
         const slackMessage = {
@@ -25,13 +202,16 @@ export function renderError(msg: string, correlationId?: string): ResponseMessag
     } catch (ex) {
         return new ResponseMessage(`Error rendering error message ${ex}`);
     }
-}
+});
 
-export function renderSuccess(msg: string): ResponseMessage {
+export const renderSuccess = deprecated({
+    alternative: "successResponse",
+    version: "0.8.0",
+}, function renderSuccess(msg: string): ResponseMessage {
     try {
         const slackMessage = { text: msg };
         return new ResponseMessage(render(slackMessage), MessageMimeTypes.SLACK_JSON);
     } catch (ex) {
         return renderError(`Error rendering success message ${ex}`);
     }
-}
+});

--- a/src/SlackMessages.ts
+++ b/src/SlackMessages.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2017 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /**
  * Construct and render slack messages according to Slack message
  * formatting: https://api.slack.com/docs/message-formatting. Customize
@@ -7,11 +23,8 @@
 /**
  * Escapes special Slack characters.
  */
-
-import { emptyString } from "./Common";
-
 export function escape(text: string): string {
-    if (!emptyString(text)) {
+    if (text) {
         return text
             .replace(/&/g, "&amp;")
             .replace(/</g, "&lt;")
@@ -26,9 +39,9 @@ export function escape(text: string): string {
  * Label is automatically escaped.
  */
 export function url(fullUrl: string, label?: string) {
-    if (!emptyString(fullUrl) && !emptyString(label)) {
+    if (fullUrl && label) {
         return `<${fullUrl}|${escape(label)}>`;
-    } else if (!emptyString(fullUrl)) {
+    } else if (fullUrl) {
         return `<${fullUrl}>`;
     } else {
         return "";
@@ -44,9 +57,9 @@ export function url(fullUrl: string, label?: string) {
  * @return properly formatted Slack user mention
  */
 export function user(userId: string, userName?: string) {
-    if (!emptyString(userId) && !emptyString(userName)) {
+    if (userId && userName) {
         return `<@${userId}|${userName}>`;
-    } else if (!emptyString(userId)) {
+    } else if (userId) {
         return `<@${userId}>`;
     } else {
         return "";
@@ -59,9 +72,9 @@ export function user(userId: string, userName?: string) {
  * When channelName is provided will add readable channel name.
  */
 export function channel(channelId: string, channelName?: string) {
-    if (!emptyString(channelId) && !emptyString(channelName)) {
+    if (channelId && channelName) {
         return `<#${channelId}|${channelName}>`;
-    } else if (!emptyString(channelId)) {
+    } else if (channelId) {
         return `<#${channelId}>`;
     } else {
         return "";
@@ -92,7 +105,7 @@ export function render(message: SlackMessage, pretty: boolean = false): string {
     if (hasItems(message.attachments)) {
         let idx = 1;
         for (const att of message.attachments) {
-            if (hasItems(att.actions) && att.callback_id == null) {
+            if (hasItems(att.actions) && !att.callback_id) {
                 att.callback_id = `cllbck${idx++}`;
             }
         }
@@ -102,61 +115,37 @@ export function render(message: SlackMessage, pretty: boolean = false): string {
 
 /** Render emoji by name */
 export function emoji(name: string) {
-    return `:${name}:`;
+    return (name) ? `:${name}:` : "";
 }
 
 /** Render bold text */
 export function bold(text: string) {
-    if (!emptyString(text)) {
-        return `*${text}*`;
-    } else {
-        return "";
-    }
+    return (text) ? `*${text}*` : "";
 }
 
 /** Render italic text */
 export function italic(text: string) {
-    if (!emptyString(text)) {
-        return `_${text}_`;
-    } else {
-        return "";
-    }
+    return (text) ? `_${text}_` : "";
 }
 
 /** Render strike-through text */
 export function strikethrough(text: string) {
-    if (!emptyString(text)) {
-        return `~${text}~`;
-    } else {
-        return "";
-    }
+    return (text) ? `~${text}~` : "";
 }
 
 /** Render single line code block */
 export function codeLine(text: string) {
-    if (!emptyString(text)) {
-        return "`" + text + "`";
-    } else {
-        return "";
-    }
+    return (text) ? "`" + text + "`" : "";
 }
 
 /** Render multiline code block */
 export function codeBlock(text: string) {
-    if (!emptyString(text)) {
-        return "```" + text + "```";
-    } else {
-        return "";
-    }
+    return (text) ? "```" + text + "```" : "";
 }
 
 /** Render bullet list item */
 export function listItem(item: string) {
-    if (!emptyString(item)) {
-        return `• ${item}`;
-    } else {
-        return "";
-    }
+    return (item) ? `• ${item}` : "";
 }
 
 /** Represents slack message object. */
@@ -241,7 +230,7 @@ export class ValidationError extends Error {
 
 /** Construct Slack button that will execute provided rug instruction. */
 export function rugButtonFrom(action: ButtonSpec, command: IdentifiableInstruction): Action {
-    if (emptyString(command.id)) {
+    if (!command.id) {
         throw new ValidationError(`Please provide a valid non-empty command id`);
     }
     const button: Action = {

--- a/test/RugMessagesTest.ts
+++ b/test/RugMessagesTest.ts
@@ -1,4 +1,34 @@
-import { renderError, renderSuccess } from "../src/RugMessages";
+/*
+ * Copyright © 2017 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MessageMimeTypes } from "@atomist/rug/operations/Handlers";
+import {
+    ErrorColor,
+    errorMessage,
+    errorResponse,
+    renderError,
+    renderSuccess,
+    SuccessColor,
+    successMessage,
+    successResponse,
+    WarningColor,
+    warningMessage,
+    warningResponse,
+} from "../src/RugMessages";
+import { Attachment, SlackMessage } from "../src/SlackMessages";
 
 import assert = require("power-assert");
 
@@ -20,4 +50,229 @@ describe("renderSuccess", () => {
             assert.equal(message.body, "{\"text\":\"Successfully ran command\"}");
         });
     });
+});
+
+describe("Standard Messages", () => {
+
+    it("should create an error message", () => {
+        const a: Attachment = {
+            fallback: "fail",
+            text: "real bad",
+        };
+        const c = "1234567890-0987654321";
+        const help = "\nPlease contact <https://atomist-community.slack.com/messages/C29GYTYDC/|Atomist support>, "
+            + "providing the correlation ID below. Sorry for the inconvenience.";
+        const e = {
+            attachments: [{
+                author_name: `Error: ${a.fallback}`,
+                author_icon: "https://images.atomist.com/rug/error-circle.png",
+                color: ErrorColor,
+                fallback: a.fallback,
+                footer: `Correlation ID: ${c}`,
+                text: a.text + help,
+                mrkdwn_in: ["text"],
+            }],
+        };
+        assert.deepEqual(errorMessage(a, c), e);
+    });
+
+    it("should create an error message without correlation ID", () => {
+        const a: Attachment = {
+            fallback: "fail",
+            text: "real bad",
+        };
+        const help = "\nPlease contact <https://atomist-community.slack.com/messages/C29GYTYDC/|Atomist support>. "
+            + "Sorry for the inconvenience.";
+        const e = {
+            attachments: [{
+                author_name: `Error: ${a.fallback}`,
+                author_icon: "https://images.atomist.com/rug/error-circle.png",
+                color: ErrorColor,
+                fallback: a.fallback,
+                text: a.text + help,
+                mrkdwn_in: ["text"],
+            }],
+        };
+        assert.deepEqual(errorMessage(a), e);
+    });
+
+    it("should create an error message with overrides", () => {
+        const a: Attachment = {
+            fallback: "fail",
+            text: "real bad",
+            color: "#000000",
+            author_name: "Me",
+            author_icon: "http://me.com/me.png",
+            footer: "shoe",
+        };
+        const c = "1234567890-0987654321";
+        const help = "\nPlease contact <https://atomist-community.slack.com/messages/C29GYTYDC/|Atomist support>. "
+            + "Sorry for the inconvenience.";
+        const e = {
+            attachments: [{
+                author_name: a.author_name,
+                author_icon: a.author_icon,
+                color: a.color,
+                fallback: a.fallback,
+                footer: a.footer,
+                text: a.text + help,
+                mrkdwn_in: ["text"],
+            }],
+        };
+        assert.deepEqual(errorMessage(a, c), e);
+    });
+
+    it("should create a success message", () => {
+        const a: Attachment = {
+            fallback: "good",
+            text: "nice",
+        };
+        const e = {
+            attachments: [{
+                author_name: `Success: ${a.fallback}`,
+                author_icon: "https://images.atomist.com/rug/check-circle.png",
+                color: SuccessColor,
+                fallback: a.fallback,
+                text: a.text,
+                mrkdwn_in: ["text"],
+            }],
+        };
+        assert.deepEqual(successMessage(a), e);
+    });
+
+    it("should create a success message with overrides", () => {
+        const a: Attachment = {
+            fallback: "good",
+            text: "nice",
+            color: "#BBBBBB",
+            author_name: "You",
+            author_icon: "http://you.com/you.png",
+            footer: "shoe",
+        };
+        const e = {
+            attachments: [{
+                author_name: a.author_name,
+                author_icon: a.author_icon,
+                color: a.color,
+                fallback: a.fallback,
+                footer: a.footer,
+                text: a.text,
+                mrkdwn_in: ["text"],
+            }],
+        };
+        assert.deepEqual(successMessage(a), e);
+    });
+
+    it("should create a warning message", () => {
+        const a: Attachment = {
+            fallback: "danger!",
+            text: "not terrible, but not great",
+        };
+        const e = {
+            attachments: [{
+                author_name: `Warning: ${a.fallback}`,
+                author_icon: "https://images.atomist.com/rug/error-square.png",
+                color: WarningColor,
+                fallback: a.fallback,
+                text: a.text,
+                mrkdwn_in: ["text"],
+            }],
+        };
+        assert.deepEqual(warningMessage(a), e);
+    });
+
+    it("should create a warning message with overrides", () => {
+        const a: Attachment = {
+            fallback: "Ahhhh",
+            text: "not rock bottom yet",
+            color: "#123456",
+            author_name: "We",
+            author_icon: "http://we.com/we.png",
+            footer: "shoe",
+        };
+        const e = {
+            attachments: [{
+                author_name: a.author_name,
+                author_icon: a.author_icon,
+                color: a.color,
+                fallback: a.fallback,
+                footer: a.footer,
+                text: a.text,
+                mrkdwn_in: ["text"],
+            }],
+        };
+        assert.deepEqual(warningMessage(a), e);
+    });
+
+});
+
+describe("Standard Responses", () => {
+
+    it("should create an error response message", () => {
+        const a: Attachment = {
+            fallback: "fail",
+            text: "real bad",
+        };
+        const c = "1234567890-0987654321";
+        const help = "\nPlease contact <https://atomist-community.slack.com/messages/C29GYTYDC/|Atomist support>, "
+            + "providing the correlation ID below. Sorry for the inconvenience.";
+        const e = {
+            attachments: [{
+                author_name: `Error: ${a.fallback}`,
+                author_icon: "https://images.atomist.com/rug/error-circle.png",
+                color: ErrorColor,
+                fallback: a.fallback,
+                footer: `Correlation ID: ${c}`,
+                text: a.text + help,
+                mrkdwn_in: ["text"],
+            }],
+        };
+        const response = errorResponse(a, c);
+        assert(response.contentType === MessageMimeTypes.SLACK_JSON);
+        const body = JSON.parse(response.body) as SlackMessage;
+        assert.deepEqual(body, e);
+    });
+
+    it("should create a success response message", () => {
+        const a: Attachment = {
+            fallback: "good",
+            text: "nice",
+        };
+        const e = {
+            attachments: [{
+                author_name: `Success: ${a.fallback}`,
+                author_icon: "https://images.atomist.com/rug/check-circle.png",
+                color: SuccessColor,
+                fallback: a.fallback,
+                text: a.text,
+                mrkdwn_in: ["text"],
+            }],
+        };
+        const response = successResponse(a);
+        assert(response.contentType === MessageMimeTypes.SLACK_JSON);
+        const body = JSON.parse(response.body) as SlackMessage;
+        assert.deepEqual(body, e);
+    });
+
+    it("should create a warning response message", () => {
+        const a: Attachment = {
+            fallback: "good",
+            text: "nice",
+        };
+        const e = {
+            attachments: [{
+                author_name: `Warning: ${a.fallback}`,
+                author_icon: "https://images.atomist.com/rug/error-square.png",
+                color: WarningColor,
+                fallback: a.fallback,
+                text: a.text,
+                mrkdwn_in: ["text"],
+            }],
+        };
+        const response = warningResponse(a);
+        assert(response.contentType === MessageMimeTypes.SLACK_JSON);
+        const body = JSON.parse(response.body) as SlackMessage;
+        assert.deepEqual(body, e);
+    });
+
 });

--- a/test/SlackMessagesTest.ts
+++ b/test/SlackMessagesTest.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2017 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {
     atChannel,
     atEveryone,
@@ -232,6 +248,10 @@ describe("Slack character escaping", () => {
     it("Will return empty string when text is undefined", () => {
         assert.equal(escape(undefined), "");
     });
+
+    it("Will return empty string when text is empty string", () => {
+        assert.equal(escape(""), "");
+    });
 });
 
 describe("Urls", () => {
@@ -249,6 +269,10 @@ describe("Urls", () => {
 
     it("Will return empty string when url is null", () => {
         assert.equal(url(null), "");
+    });
+
+    it("Will return empty string when url is empty string", () => {
+        assert.equal(url(""), "");
     });
 });
 
@@ -274,6 +298,10 @@ describe("User links", () => {
     it("Will return empty string when userId is null", () => {
         assert.equal(user(null), "");
     });
+
+    it("Will return empty string when userId is empty string", () => {
+        assert.equal(user(""), "");
+    });
 });
 
 describe("Channel links", () => {
@@ -297,6 +325,10 @@ describe("Channel links", () => {
 
     it("Will return empty string when channelId is null", () => {
         assert.equal(channel(null), "");
+    });
+
+    it("Will return empty string when channelId is empty string", () => {
+        assert.equal(channel(""), "");
     });
 });
 
@@ -327,6 +359,10 @@ describe("Markdown", () => {
         assert.equal(bold(null), "");
     });
 
+    it("bold will return empty string when text is empty string", () => {
+        assert.equal(bold(""), "");
+    });
+
     it("Can render italic text", () => {
         assert.equal(italic("some text"), "_some text_");
     });
@@ -337,6 +373,10 @@ describe("Markdown", () => {
 
     it("italic will return empty string when text is null", () => {
         assert.equal(italic(null), "");
+    });
+
+    it("italic will return empty string when text is empty string", () => {
+        assert.equal(italic(""), "");
     });
 
     it("Can render strike-through text", () => {
@@ -351,6 +391,10 @@ describe("Markdown", () => {
         assert.equal(strikethrough(null), "");
     });
 
+    it("strikethrough will return empty string when text is empty string", () => {
+        assert.equal(strikethrough(""), "");
+    });
+
     it("Can render single line code block", () => {
         assert.equal(codeLine("some text"), "`some text`");
     });
@@ -361,6 +405,10 @@ describe("Markdown", () => {
 
     it("codeLine will return empty string when text is null", () => {
         assert.equal(codeLine(null), "");
+    });
+
+    it("codeLine will return empty string when text is empty string", () => {
+        assert.equal(codeLine(""), "");
     });
 
     it("Can render multiline line code block", () => {
@@ -375,6 +423,10 @@ describe("Markdown", () => {
         assert.equal(codeBlock(null), "");
     });
 
+    it("codeBlock will return empty string when text is empty string", () => {
+        assert.equal(codeBlock(""), "");
+    });
+
     it("Can render list item", () => {
         assert.equal(listItem("some text"), "• some text");
     });
@@ -385,5 +437,9 @@ describe("Markdown", () => {
 
     it("listItem will return empty string when text is null", () => {
         assert.equal(listItem(null), "");
+    });
+
+    it("listItem will return empty string when text is empty string", () => {
+        assert.equal(listItem(""), "");
     });
 });

--- a/tslint.json
+++ b/tslint.json
@@ -14,7 +14,8 @@
             "never-prefix"
         ],
         "max-classes-per-file": false,
-        "object-literal-sort-keys": false
+        "object-literal-sort-keys": false,
+        "no-console": false
     },
     "rulesDirectory": []
 }


### PR DESCRIPTION
Add standard formatted Slack messages for success, error, and
warning.  Add standard colors for each case.